### PR TITLE
PER-22 Improve footer links accessibility

### DIFF
--- a/src/components/typography.tsx
+++ b/src/components/typography.tsx
@@ -73,7 +73,7 @@ export const ArticleTitle = ({ children, className }: TypographyProps) => {
 
 export const LinkText = ({ children }: LinkProps) => {
   return (
-    <Paragraph className='transition-colors ease-out duration-150 mt-4 mb-0 mx-0 !text-neutral-500 hover:!text-neutral-700'>
+    <Paragraph className='transition-colors ease-out duration-150 mt-4 mb-0 mx-0 underline underline-offset-4 !text-neutral-400 hover:!text-neutral-700'>
       {children}
     </Paragraph>
   );


### PR DESCRIPTION
Introduced changes:
- new lighthouse score for accessibility is 100 because of the proper contrast between link color and background color. 
- links are now underlined